### PR TITLE
If player is holding a Hoe, harvest crops

### DIFF
--- a/src/java/io/github/safyre/harvester/HarvestListener.java
+++ b/src/java/io/github/safyre/harvester/HarvestListener.java
@@ -32,7 +32,12 @@ public class HarvestListener implements Listener {
     @EventHandler
     public void onPlayerInteract(PlayerInteractEvent event) {
         if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-            if (event.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.AIR) && event.getPlayer().getInventory().getItemInOffHand().getType().equals(Material.AIR)) {
+            Material mainHand = event.getPlayer().getInventory().getItemInMainHand().getType();
+            if (mainHand.equals(Material.WOODEN_HOE) ||
+                mainHand.equals(Material.STONE_HOE) ||
+                mainHand.equals(Material.IRON_HOE) ||
+                mainHand.equals(Material.DIAMOND_HOE) ||
+                mainHand.equals(Material.AIR) && event.getPlayer().getInventory().getItemInOffHand().getType().equals(Material.AIR)) {
                 try {
                     Block block = event.getClickedBlock();
                     BlockData blockData = block.getBlockData();


### PR DESCRIPTION
Expand the conditions checked when a player right clicks on a crop.  Harvesting on the existing condition of both hands empty or the main hand holding a wood, stone, iron, or diamond hoe.